### PR TITLE
Feature/#1 Abstract Factory 적용

### DIFF
--- a/src/main/java/GameApp.java
+++ b/src/main/java/GameApp.java
@@ -1,11 +1,11 @@
 import game.Game;
 import game.dto.InferResult;
 import game.exception.GameException;
-import ui.TerminalFactory;
+import ui.terminal.TerminalFactory;
 import ui.UIFactory;
 import ui.exception.UIException;
-import ui.interactor.Interactor;
-import ui.resolver.Resolver;
+import ui.Interactor;
+import ui.Resolver;
 
 import java.util.List;
 

--- a/src/main/java/GameApp.java
+++ b/src/main/java/GameApp.java
@@ -1,11 +1,11 @@
 import game.Game;
 import game.dto.InferResult;
 import game.exception.GameException;
+import ui.TerminalFactory;
+import ui.UIFactory;
 import ui.exception.UIException;
 import ui.interactor.Interactor;
-import ui.interactor.TerminalInteractor;
 import ui.resolver.Resolver;
-import ui.resolver.TerminalResolver;
 
 import java.util.List;
 
@@ -16,8 +16,9 @@ public class GameApp {
     public static void run() {
         // di
         Game game = new Game();
-        Resolver resolver = new TerminalResolver();
-        Interactor interactor = new TerminalInteractor();
+        UIFactory uiFactory = new TerminalFactory();
+        Resolver resolver = uiFactory.createResolver();
+        Interactor interactor = uiFactory.createInteractor();
 
         game.init();
         interactor.write(resolver.startMessage());

--- a/src/main/java/ui/Interactor.java
+++ b/src/main/java/ui/Interactor.java
@@ -1,4 +1,4 @@
-package ui.interactor;
+package ui;
 
 /**
  * 사용자로부터의 입력,
@@ -9,7 +9,7 @@ public interface Interactor {
     /**
      * if inputData is empty, must be blocked.
      *
-     * @return
+     * @return boolean
      */
     boolean hasRead();
 

--- a/src/main/java/ui/Resolver.java
+++ b/src/main/java/ui/Resolver.java
@@ -1,6 +1,7 @@
-package ui.resolver;
+package ui;
 
 import game.dto.InferResult;
+import ui.terminal.TerminalResolver;
 
 import java.util.List;
 

--- a/src/main/java/ui/TerminalFactory.java
+++ b/src/main/java/ui/TerminalFactory.java
@@ -1,0 +1,19 @@
+package ui;
+
+import ui.interactor.Interactor;
+import ui.interactor.TerminalInteractor;
+import ui.resolver.Resolver;
+import ui.resolver.TerminalResolver;
+
+public class TerminalFactory implements UIFactory {
+
+    @Override
+    public Interactor createInteractor() {
+        return new TerminalInteractor();
+    }
+
+    @Override
+    public Resolver createResolver() {
+        return new TerminalResolver();
+    }
+}

--- a/src/main/java/ui/UIFactory.java
+++ b/src/main/java/ui/UIFactory.java
@@ -1,8 +1,5 @@
 package ui;
 
-import ui.interactor.Interactor;
-import ui.resolver.Resolver;
-
 public interface UIFactory {
     Interactor createInteractor();
     Resolver createResolver();

--- a/src/main/java/ui/UIFactory.java
+++ b/src/main/java/ui/UIFactory.java
@@ -1,0 +1,9 @@
+package ui;
+
+import ui.interactor.Interactor;
+import ui.resolver.Resolver;
+
+public interface UIFactory {
+    Interactor createInteractor();
+    Resolver createResolver();
+}

--- a/src/main/java/ui/terminal/TerminalFactory.java
+++ b/src/main/java/ui/terminal/TerminalFactory.java
@@ -1,9 +1,8 @@
-package ui;
+package ui.terminal;
 
-import ui.interactor.Interactor;
-import ui.interactor.TerminalInteractor;
-import ui.resolver.Resolver;
-import ui.resolver.TerminalResolver;
+import ui.Interactor;
+import ui.Resolver;
+import ui.UIFactory;
 
 public class TerminalFactory implements UIFactory {
 

--- a/src/main/java/ui/terminal/TerminalInteractor.java
+++ b/src/main/java/ui/terminal/TerminalInteractor.java
@@ -1,4 +1,6 @@
-package ui.interactor;
+package ui.terminal;
+
+import ui.Interactor;
 
 import java.util.Scanner;
 

--- a/src/main/java/ui/terminal/TerminalResolver.java
+++ b/src/main/java/ui/terminal/TerminalResolver.java
@@ -1,7 +1,8 @@
-package ui.resolver;
+package ui.terminal;
 
 import game.dto.InferResult;
 import ui.exception.UIException;
+import ui.Resolver;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/ui/resolver/TerminalResolverTest.java
+++ b/src/test/java/ui/resolver/TerminalResolverTest.java
@@ -3,6 +3,7 @@ package ui.resolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import ui.exception.UIException;
+import ui.terminal.TerminalResolver;
 
 import java.util.List;
 


### PR DESCRIPTION
#1 

terminal resolver -> terminal interactor만 통신해야 함. 따라서 강제할 수 있는 수단 필요.
1. abstract factory로만 객체를 생성할 수 있게 강제 하도록 하였음.
2. 직접 구체적인 클래스를 접근하여 객체를 생성할 수 없도록, TerminalResolver, TerminalInteractor의 access level을 package private로 설정.
